### PR TITLE
Workaround for Unicode issue

### DIFF
--- a/jakarta-persistence/src/main/java/os/expert/examples/Address.java
+++ b/jakarta-persistence/src/main/java/os/expert/examples/Address.java
@@ -54,8 +54,8 @@ public class Address {
     public static Address of(Faker faker){
         Address entity = new Address();
         var address = faker.address();
-        entity.city = address.city();
-        entity.country = address.country();
+        entity.city = Beer.stripUnicode(address.city());
+        entity.country = Beer.stripUnicode(address.country());
         return entity;
     }
 

--- a/jakarta-persistence/src/main/java/os/expert/examples/Beer.java
+++ b/jakarta-persistence/src/main/java/os/expert/examples/Beer.java
@@ -12,7 +12,8 @@ import java.util.Objects;
 public class Beer {
 
     @Id
-    private String id;
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long id;
 
     @Column
    private String name;
@@ -29,10 +30,10 @@ public class Beer {
     @OneToOne(cascade = CascadeType.ALL)
     @JoinColumn(name = "address_id", referencedColumnName = "id")
     private Address address;
-    @Column
+    @Column(name = "BEERUSER") //USER is reserved in Postgres
     private  String user;
 
-    public String id() {
+    public long id() {
         return id;
     }
 
@@ -94,13 +95,25 @@ public class Beer {
     public static Beer of(Faker faker){
         var beer = faker.beer();
         Beer entity = new Beer();
-        entity.name = beer.name();
-        entity.style = beer.style();
-        entity.hop = beer.hop();
-        entity.yeast = beer.yeast();
-        entity.malt = beer.malt();
-        entity.user = faker.dragonBall().character();
+        entity.name = stripUnicode(beer.name());
+        entity.style = stripUnicode(beer.style());
+        entity.hop = stripUnicode(beer.hop());
+        entity.yeast = stripUnicode(beer.yeast());
+        entity.malt = stripUnicode(beer.malt());
+        entity.user = stripUnicode(faker.dragonBall().character());
         entity.address = Address.of(faker);
         return entity;
+    }
+
+    //OpenLiberty's JPA implemenation doesn't allow Unicode on Postgres
+    //This is temporary until that can be fixed and released.
+    public static String stripUnicode(String s) {
+        StringBuilder sb = new StringBuilder();
+        for (int c : s.toCharArray()) {
+            if (c < 128) {
+                sb.append((char)c);
+            }
+        }
+        return sb.toString();
     }
 }

--- a/jakarta-persistence/src/main/liberty/config/server.xml
+++ b/jakarta-persistence/src/main/liberty/config/server.xml
@@ -7,23 +7,12 @@
         <feature>persistence-3.1</feature>
     </featureManager>
     
-
     <httpEndpoint id="defaultHttpEndpoint"
-                    host="*"
+                  host="*"
                   httpPort="9080"
                   httpsPort="9443"/>
 
-    <webApplication location="${project.name}.war" contextRoot="${app.context.root}">
-        <classloader apiTypeVisibility="+third-party" />
-    </webApplication>
-    <mpMetrics authentication="false"/>
-
-    <!-- This is the keystore that will be used by SSL and by JWT. -->
-    <keyStore id="defaultKeyStore" location="public.jks" type="JKS" password="atbash" />
-
-
-    <!-- The MP JWT configuration that injects the caller's JWT into a ResourceScoped bean for inspection. -->
-    <mpJwt id="jwtUserConsumer" keyName="theKeyId" audiences="targetService" issuer="${jwt.issuer}"/>
+    <webApplication location="${project.name}.war" contextRoot="${app.context.root}"/>
 
     <library id="PostgresLib">
 		<fileset dir="${server.config.dir}/lib/postgres" includes="*.jar"/>


### PR DESCRIPTION
OpenLiberty currently doesn't allow full Unicode support through JPA. I'm adding a fix, but I don't expect it to be available until 23.0.0.9, so in the meantime this will need a workaround.